### PR TITLE
Replace `behat/mink-extension` with `friends-of-behat/mink-extension`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.2 || ^8.0",
-        "behat/mink-extension": "^2.3",
+        "friends-of-behat/mink-extension": "^2.3",
         "rpkamp/mailhog-behat-extension": "^0.6.6",
         "symfony/dom-crawler": "^3.4 || ^4.0 || ^5.0"
     },


### PR DESCRIPTION
Hey, thanks for this library! I had some problems upgrading my project to Symfony 5.3 / PHP 8. These were fixed by replacing [behat/mink-extension](https://github.com/Behat/MinkExtension) with [friends-of-behat/mink-extension](https://github.com/FriendsOfBehat/MinkExtension).

Advantages:

 * This is the fork of MinkExtension library that supports PHP ^7.2 and supports Symfony ^4.4 and ^5.0.
