### PR TITLE
Added support for Symfony 6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "behat/mink-extension": "^2.3",
-        "rpkamp/mailhog-behat-extension": "^0.6.6",
-        "symfony/dom-crawler": "^3.4 || ^4.0 || ^5.0"
+        "rpkamp/mailhog-behat-extension": "^1.0.0",
+        "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "php-http/curl-client": "^2.0",
@@ -36,7 +36,7 @@
         "doctrine/coding-standard": "^8.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "egulias/email-validator": "^2.1.23",
-	"nyholm/psr7": "^1.3",
+	    "nyholm/psr7": "^1.3",
         "phpmd/phpmd": "^2.9"
     }
 }


### PR DESCRIPTION
This commit adds support for Symfony 6. To successfully use it in your project you might need to require `friends-of-behat/mink-extension`. It replaces `behat/mink-extension` and can use Symfony 6 components where the original doesn't.