### PR TITLE
Added support for Symfony 7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.4 || ^8.0",
-        "behat/mink-extension": "^2.3",
+        "friends-of-behat/mink-extension": "^2.3",
         "rpkamp/mailhog-behat-extension": "^1.0.0",
         "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "behat/mink-extension": "^2.3",
         "rpkamp/mailhog-behat-extension": "^1.0.0",
-        "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0"
+        "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "php-http/curl-client": "^2.0",


### PR DESCRIPTION
This commit adds support for Symfony 7, required for Drupal 11 compatibility. Aligns with `friends-of-behat/mink-extension:2.7.5` constraints.